### PR TITLE
Chore: Reduce redundunt requires in spec files

### DIFF
--- a/spec/image_loader/mini_magick_spec.rb
+++ b/spec/image_loader/mini_magick_spec.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
-require "shrine"
-require "shrine/storage/memory"
-require "shrine/plugins/thumbhash"
 require "shrine/plugins/thumbhash/image_loader/mini_magick"
 
 RSpec.describe Shrine::Plugins::Thumbhash::ImageLoader::MiniMagick do

--- a/spec/image_loader/ruby_vips_spec.rb
+++ b/spec/image_loader/ruby_vips_spec.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
-require "shrine"
-require "shrine/storage/memory"
-require "shrine/plugins/thumbhash"
 require "shrine/plugins/thumbhash/image_loader/ruby_vips"
 
 RSpec.describe Shrine::Plugins::Thumbhash::ImageLoader::RubyVips do # rubocop:disable Metrics/BlockLength

--- a/spec/thumbhash_spec.rb
+++ b/spec/thumbhash_spec.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
-require "shrine"
 require "shrine/storage/memory"
-require "shrine/plugins/thumbhash"
 
 RSpec.describe Shrine::Plugins::Thumbhash do # rubocop:disable Metrics/BlockLength
   it "has a version number" do


### PR DESCRIPTION
I confirm that each spec files can run by this command.
`find -name *_spec.rb | xargs -n1 bundle ex rspec`